### PR TITLE
Handle GitHub organization name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -30,7 +30,7 @@
     "license": {
         "start_header": null,
         "end_header": null,
-        "source": "https://github.com/open-source-economics/Behavioral-Responses/blob/master/LICENSE.md",
+        "source": "https://github.com/PSLmodels/Behavioral-Responses/blob/master/LICENSE.md",
         "data": "<p>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</p>",
         "type": "html"
     },
@@ -39,7 +39,7 @@
         "end_header": null,
         "source": null,
         "type": "html",
-        "data": "<a href=\"http://open-source-economics.github.io/Behavioral-Responses/index.html\">http://open-source-economics.github.io/Behavioral-Responses/index.html</a>"
+        "data": "<a href=\"http://PSLmodels.github.io/Behavioral-Responses/index.html\">http://PSLmodels.github.io/Behavioral-Responses/index.html</a>"
     },
     "user_changelog": {
         "start_header": null,
@@ -121,14 +121,14 @@
     "public_issue_tracker": {
         "start_header": null,
         "end_header": null,
-        "data": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">https://github.com/open-source-economics/Behavioral-Responses/issues</a>",
+        "data": "<a href=\"https://github.com/PSLmodels/Behavioral-Responses/issues\">https://github.com/PSLmodels/Behavioral-Responses/issues</a>",
         "source": null,
         "type": "html"
     },
     "public_qanda": {
         "start_header": null,
         "end_header": null,
-        "data": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/issues\">https://github.com/open-source-economics/Behavioral-Responses/issues</a>",
+        "data": "<a href=\"https://github.com/PSLmodels/Behavioral-Responses/issues\">https://github.com/PSLmodels/Behavioral-Responses/issues</a>",
         "source": null,
         "type": "html"
     },
@@ -142,14 +142,14 @@
     "unit_test": {
         "start_header": null,
         "end_header": null,
-        "data": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a>",
+        "data": "<a href=\"https://github.com/PSLmodels/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/PSLmodels/Behavioral-Responses/tree/master/behresp/tests</a>",
         "source": null,
         "type": "html"
     },
     "integration_test": {
         "start_header": null,
         "end_header": null,
-        "data": "<a href=\"https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/open-source-economics/Behavioral-Responses/tree/master/behresp/tests</a>",
+        "data": "<a href=\"https://github.com/PSLmodels/Behavioral-Responses/tree/master/behresp/tests\">https://github.com/PSLmodels/Behavioral-Responses/tree/master/behresp/tests</a>",
         "source": null,
         "type": "html"
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
-[![Build Status](https://travis-ci.org/open-source-economics/Behavioral-Responses.svg?branch=master)](https://travis-ci.org/open-source-economics/Behavioral-Responses)
-[![Codecov](https://codecov.io/gh/open-source-economics/Behavioral-Responses/branch/master/graph/badge.svg)](https://codecov.io/gh/open-source-economics/Behavioral-Responses)
+[![Build Status](https://travis-ci.org/PSLmodels/Behavioral-Responses.svg?branch=master)](https://travis-ci.org/PSLmodels/Behavioral-Responses)
+[![Codecov](https://codecov.io/gh/PSLmodels/Behavioral-Responses/branch/master/graph/badge.svg)](https://codecov.io/gh/PSLmodels/Behavioral-Responses)
 
 
 Developing Behavioral-Responses
@@ -10,7 +10,7 @@ This document tells you how to begin contributing to
 Behavioral-Responses by reporting a bug, improving the documentation,
 or making an enhancement to the Python source code.  If you only want
 to **use** Behavioral-Responses, you should begin by reading the [user
-documentation](https://open-source-economics.github.io/Behavioral-Responses/)
+documentation](https://PSLmodels.github.io/Behavioral-Responses/)
 that describes how to write Python scripts that use
 Behavioral-Responses on your own computer.
 
@@ -22,7 +22,7 @@ Behavioral-Responses, which is part of the Policy Simulation Library (PSL)
 collection of USA tax models, estimates partial-equilibrium behavioral
 responses to changes in the US federal individual income and payroll
 tax system as simulated by
-[Tax-Calculator](https://github.com/open-source-economics/Tax-Calculator)
+[Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator)
 
 
 Disclaimer
@@ -40,11 +40,11 @@ Getting Started
 ---------------
 
 If you want to **report a bug**, create a new issue
-[here](https://github.com/open-source-economics/Behavioral-Responses/issues)
+[here](https://github.com/PSLmodels/Behavioral-Responses/issues)
 providing details on what you think is wrong with Behavioral-Responses.
 
 If you want to **request an enhancement**, create a new issue
-[here](https://github.com/open-source-economics/Behavioral-Responses/issues)
+[here](https://github.com/PSLmodels/Behavioral-Responses/issues)
 providing details on what you think should be added to Behavioral-Responses.
 
 If you want to **propose code changes**, follow the directions in the
@@ -54,12 +54,12 @@ on how to fork and clone the Behavioral-Responses git repository.
 Before developing any code changes be sure to read completely the
 Tax-Calculator Contributor Guide and then read about the
 [Tax-Calculator pull-request
-workflow](https://github.com/open-source-economics/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).
+workflow](https://github.com/PSLmodels/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).
 When reading both documents, be sure to mentally substitute
 Behavioral-Response for Tax-Calculator and behresp for taxcalc.
 
 The Behavioral-Responses [release
-history](https://github.com/open-source-economics/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history)
+history](https://github.com/PSLmodels/Behavioral-Responses/blob/master/RELEASES.md#tax-calculator-release-history)
 provides a high-level summary of past pull requests and access to a
 complete list of merged, closed, and pending pull requests.
 
@@ -70,8 +70,8 @@ Citing Behavioral-Responses
 Please cite the source of your analysis as "Behavioral-Responses
 release #.#.#, author's calculations." If you wish to link to
 Behavioral-Responses,
-https://open-source-economics.github.io/Behavioral-Responses/ is
-preferred.  Additionally, we strongly recommend that you describe the
+https://PSLmodels.github.io/Behavioral-Responses/ is preferred.
+Additionally, we strongly recommend that you describe the
 elasticity assumptions used, and provide a link to the materials
 required to replicate your analysis or, at least, note that those
 materials are available upon request.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,20 +1,20 @@
 BEHAVIORAL-RESPONSES RELEASE HISTORY
 ====================================
-Go [here](https://github.com/open-source-economics/Behavioral-Responses/pulls?q=is%3Apr+is%3Aclosed)
+Go [here](https://github.com/PSLmodels/Behavioral-Responses/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
 
 2018-11-13 Release 0.4.0
 ------------------------
 (last merged pull request is
-[#21](https://github.com/open-source-economics/Behavioral-Responses/pull/21))
+[#21](https://github.com/PSLmodels/Behavioral-Responses/pull/21))
 
 **API Changes**
 - Change documentation to state that Behavioral-Responses `behresp` packages are available **only** via the `PSLmodels` Anaconda Cloud channel
-  [[#20](https://github.com/open-source-economics/Behavioral-Responses/pull/20)
+  [[#20](https://github.com/PSLmodels/Behavioral-Responses/pull/20)
   by Martin Holmer]
 - Remove `versioneer.py` and `taxcalc/_version.py` and related code now that Package-Builder is handling version specification
-  [[#21](https://github.com/open-source-economics/Behavioral-Responses/pull/21)
+  [[#21](https://github.com/PSLmodels/Behavioral-Responses/pull/21)
   by Martin Holmer]
 
 **New Features**
@@ -30,11 +30,11 @@ _Earlier Releases:_
 2018-11-06 Release 0.3.0
 ------------------------
 (last merged pull request is
-[#18](https://github.com/open-source-economics/Behavioral-Responses/pull/18))
+[#18](https://github.com/PSLmodels/Behavioral-Responses/pull/18))
 
 **API Changes**
 - Simplify specification of package dependencies
-  [[#18](https://github.com/open-source-economics/Behavioral-Responses/pull/18)
+  [[#18](https://github.com/PSLmodels/Behavioral-Responses/pull/18)
   by Martin Holmer]
 
 **New Features**
@@ -47,11 +47,11 @@ _Earlier Releases:_
 2018-11-03 Release 0.2.0
 ------------------------
 (last merged pull request is
-[#15](https://github.com/open-source-economics/Behavioral-Responses/pull/15))
+[#15](https://github.com/PSLmodels/Behavioral-Responses/pull/15))
 
 **API Changes**
 - Make specification of required package versions comply with style in conda cheat sheet
-  [[#15](https://github.com/open-source-economics/Behavioral-Responses/pull/15)
+  [[#15](https://github.com/PSLmodels/Behavioral-Responses/pull/15)
   by Martin Holmer]
 
 **New Features**
@@ -64,20 +64,20 @@ _Earlier Releases:_
 2018-11-01 Release 0.1.0
 ------------------------
 (last merged pull request is
-[#11](https://github.com/open-source-economics/Behavioral-Responses/pull/11))
+[#11](https://github.com/PSLmodels/Behavioral-Responses/pull/11))
 
 **API Changes**
 - Copy Tax-Calculator top-level files to Behavioral-Responses repo
-  [[#2](https://github.com/open-source-economics/Behavioral-Responses/pull/2)
+  [[#2](https://github.com/PSLmodels/Behavioral-Responses/pull/2)
   by Martin Holmer]
 - Move Tax-Calculator Behavior class logic/tests to Behavioral-Responses repo
-  [[#3](https://github.com/open-source-economics/Behavioral-Responses/pull/3)
+  [[#3](https://github.com/PSLmodels/Behavioral-Responses/pull/3)
   by Martin Holmer]
 - Streamline tests to use less memory
-  [[#8](https://github.com/open-source-economics/Behavioral-Responses/pull/8)
+  [[#8](https://github.com/PSLmodels/Behavioral-Responses/pull/8)
   by Martin Holmer with assistance from Matt Jensen]
 - Add user documentation for Behavioral-Responses package
-  [[#11](https://github.com/open-source-economics/Behavioral-Responses/pull/11)
+  [[#11](https://github.com/PSLmodels/Behavioral-Responses/pull/11)
   by Martin Holmer]
 
 **New Features**

--- a/behresp/conftest.py
+++ b/behresp/conftest.py
@@ -1,2 +1,2 @@
 # This empty conftest file exists to help pytest discover the behresp package.
-# See https://github.com/open-source-economics/Tax-Calculator/issues/1186
+# See https://github.com/PSLmodels/Tax-Calculator/issues/1186

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,9 +4,11 @@ package:
 
 requirements:
   build:
+    - python
     - taxcalc
 
   run:
+    - python
     - taxcalc
 
 test:
@@ -14,4 +16,4 @@ test:
     - behresp
 
 about:
-  home: https://github.com/open-source-economics/Behavioral-Response
+  home: https://github.com/PSLmodels/Behavioral-Response

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,17 +14,17 @@ div { max-width: 19cm }
 <p>This document tells you how to use Behavioral-Responses, an
 open-source model in the Policy Simulation Library (PSL) collection of
 USA tax models.  You always use Behavioral-Responses in conjunction with
-<a href="https://open-source-economics.github.io/Tax-Calculator/">
+<a href="https://PSLmodels.github.io/Tax-Calculator/">
 Tax-Calculator</a>, the static-analysis model in the PSL collection of
 USA tax models, by writing and executing a Python script.  For an
 introduction to writing Python scripts using Tax-Calculator, read the
 tested recipes in our
-<a href="https://open-source-economics.github.io/Tax-Calculator/cookbook.html">
+<a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
 Tax-Calculator Cookbook</a>.  If you want to participate in the
 development of Behavioral-Responses &mdash; by asking a question,
 reporting a bug, improving the documentation or making an enhancement
 to the Python source code &mdash; you should go to
-the <a href="https://github.com/open-source-economics/Behavioral-Responses">
+the <a href="https://github.com/PSLmodels/Behavioral-Responses">
 developer website</a>.</p>
 
 <p>Please cite the source of your analysis as <q>Behavioral-Responses
@@ -44,7 +44,7 @@ that those materials are available upon request.</p>
 <h2 id="paramlogic">Response Parameters and Logic</h2>
 
 <p>The Behavioral-Responses parameters and logic are described in the
-<a href="https://github.com/open-source-economics/Behavioral-Responses/blob/master/behresp/behavior.py">
+<a href="https://github.com/PSLmodels/Behavioral-Responses/blob/master/behresp/behavior.py">
 behavior.py</a> file, where the parameters are defined in the
 <kbd>PARAM_INFO</kbd> dictionary, and the logic of how those parameters
 are used along with Tax-Calculator results is defined in the
@@ -53,7 +53,7 @@ are used along with Tax-Calculator results is defined in the
 <p>An interface to Behavioral-Responses for the
 <a href="https://www.ospc.org/taxbrain/">TaxBrain web application</a>
 is located in the
-<a href="https://github.com/open-source-economics/Behavioral-Responses/blob/master/behresp/tbi.py">
+<a href="https://github.com/PSLmodels/Behavioral-Responses/blob/master/behresp/tbi.py">
 tbi.py</a> file.  But this is of interest only to TaxBrain developers.</p>
 
 <p><a href="#doc">Back to Document Contents</a></p>
@@ -63,9 +63,9 @@ tbi.py</a> file.  But this is of interest only to TaxBrain developers.</p>
 
 <p>A tested recipe for using the Behavioral-Responses parameters and
 <kbd>response</kbd> function is contained in recipe 2 of the
-<a href="https://open-source-economics.github.io/Tax-Calculator/cookbook.html">
+<a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
 Tax-Calculator Cookbook</a> and in the <kbd>test_response_function</kbd> in the
-<a href="https://github.com/open-source-economics/Behavioral-Responses/blob/master/behresp/tests/test_behavior.py">
+<a href="https://github.com/PSLmodels/Behavioral-Responses/blob/master/behresp/tests/test_behavior.py">
 test_behavior.py</a> file.</p>
 
 <p>Notice that when writing a script like this you must import both
@@ -90,7 +90,7 @@ all filing units.  If you want to estimate responses where the value
 of the parameters vary across (say, earnings) groups, you can use the
 Tax-Calculator <kbd>quantity_response</kbd> function.  A recipe for
 doing this is contained in the
-<a href="https://open-source-economics.github.io/Tax-Calculator/cookbook.html">
+<a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
 Tax-Calculator Cookbook</a>.  That recipe simply estimates the
 responses.  But the techniques used in the Behavioral-Responses
 <kbd>response</kbd> function can be used to apply the estimated

--- a/environment.yml
+++ b/environment.yml
@@ -2,4 +2,5 @@ name: behresp-dev
 channels:
 - PSLmodels
 dependencies:
+- python
 - taxcalc

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ version = '0.0.0'
 
 config = {
     'description': 'Behavioral Responses',
-    'url': 'https://github.com/open-source-economics/Behavioral-Responses',
-    'download_url': 'https://github.com/open-source-economics/Behavioral-Responses',
+    'url': 'https://github.com/PSLmodels/Behavioral-Responses',
+    'download_url': 'https://github.com/PSLmodels/Behavioral-Responses',
     'description': 'behresp',
     'long_description': longdesc,
     'version': version,


### PR DESCRIPTION
This pull request simply changes "open-source-economics" to "PSLmodels".