### PR TITLE
Remove obsolete .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-behresp/_version.py export-subst


### PR DESCRIPTION
Should have been removed when `behresp/_version.py` file was removed.