### PR TITLE
Add quantity_response function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,35 @@
 [![Codecov](https://codecov.io/gh/PSLmodels/Behavioral-Responses/branch/master/graph/badge.svg)](https://codecov.io/gh/PSLmodels/Behavioral-Responses)
 
 
-Developing Behavioral-Responses
-===============================
+Behavioral-Responses
+====================
 
-This document tells you how to begin contributing to
-Behavioral-Responses by reporting a bug, improving the documentation,
-or making an enhancement to the Python source code.  If you only want
-to **use** Behavioral-Responses, you should begin by reading the [user
-documentation](https://PSLmodels.github.io/Behavioral-Responses/)
-that describes how to write Python scripts that use
-Behavioral-Responses on your own computer.
+This document tells you how to begin using or contributing to
+Behavioral-Responses.  Begin by reading the [Tax-Calculator user
+guide](https://PSLmodels.github.io/Tax-Calculator/) and then the
+[Behavioral-Responses user
+guide](https://PSLmodels.github.io/Behavioral-Responses/) that
+describes how to write Python scripts that use Behavioral-Responses
+together with Tax-Calculator on your own computer.
 
 
 What is Behavioral-Responses?
 -----------------------------
 
-Behavioral-Responses, which is part of the Policy Simulation Library (PSL)
-collection of USA tax models, estimates partial-equilibrium behavioral
-responses to changes in the US federal individual income and payroll
-tax system as simulated by
-[Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator)
+Behavioral-Responses, which is part of the Policy Simulation Library
+(PSL) collection of USA tax models, estimates partial-equilibrium
+behavioral responses to changes in the US federal individual income
+and payroll tax system as simulated by
+[Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator).  It
+provides two ways of doing this: (1) the `response` function, which
+contains higher-level logic that supports the TaxBrain "Partial
+Equilibrium Simulation" capability and requires specification of only
+the elasticities, and (2) the `quantity_response` function, which
+contains lower-level logic that requires specification of the quantity
+whose response is to be estimated, requires specification of the
+marginal tax rates and elasticities to be used in the response
+calculation, and allows the response estimation to be conducted by
+subgroup with different elasticities for each subgroup.
 
 
 Disclaimer
@@ -49,11 +58,11 @@ If you want to **request an enhancement**, create a new issue
 providing details on what you think should be added to Behavioral-Responses.
 
 If you want to **propose code changes**, follow the directions in the
-[Tax-Calculator Contributor
-Guide](https://taxcalc.readthedocs.io/en/latest/contributor_guide.html)
+[Tax-Calculator contributor
+guide](https://github.com/PSLmodels/Tax-Calculator/blob/master/CONTRIBUTING.md#tax-calculator-contributor-guide)
 on how to fork and clone the Behavioral-Responses git repository.
 Before developing any code changes be sure to read completely the
-Tax-Calculator Contributor Guide and then read about the
+Tax-Calculator contributor guide and then read about the
 [Tax-Calculator pull-request
 workflow](https://github.com/PSLmodels/Tax-Calculator/blob/master/WORKFLOW.md#tax-calculator-pull-request-workflow).
 When reading both documents, be sure to mentally substitute
@@ -73,6 +82,6 @@ release #.#.#, author's calculations." If you wish to link to
 Behavioral-Responses,
 https://PSLmodels.github.io/Behavioral-Responses/ is preferred.
 Additionally, we strongly recommend that you describe the
-elasticity assumptions used, and provide a link to the materials
+elasticity parameters used, and provide a link to the materials
 required to replicate your analysis or, at least, note that those
 materials are available upon request.

--- a/behresp/__init__.py
+++ b/behresp/__init__.py
@@ -1,7 +1,7 @@
 """
 Specify what is available to import from the behresp package.
 """
-from behresp.behavior import PARAM_INFO, response
+from behresp.behavior import PARAM_INFO, response, quantity_response
 from behresp.tbi import parameter_errors, run_nth_year_behresp_model
 
 __version__ = '0.0.0'

--- a/behresp/behavior.py
+++ b/behresp/behavior.py
@@ -255,3 +255,92 @@ def response(calc_1, calc_2, behavior, dump=False):
     del calc2_behv
     # Return the two dataframes
     return (df1, df2)
+
+
+def quantity_response(quantity,
+                      price_elasticity,
+                      aftertax_price1,
+                      aftertax_price2,
+                      income_elasticity,
+                      aftertax_income1,
+                      aftertax_income2):
+    """
+    Calculate dollar change in quantity using a log-log response equation,
+    which assumes that the proportional change in the quantity is equal to
+    the sum of two terms:
+    (1) the proportional change in the quanitity's marginal aftertax price
+        times an assumed price elasticity, and
+    (2) the proportional change in aftertax income
+        times an assumed income elasticity.
+
+    Parameters
+    ----------
+    quantity: numpy array
+        pre-response quantity whose response is being calculated
+
+    price_elasticity: float
+        coefficient of the percentage change in aftertax price of
+        the quantity in the log-log response equation
+
+    aftertax_price1: numpy array
+        marginal aftertax price of the quanitity under baseline policy
+          Note that this function forces prices to be in [0.01, inf] range,
+          but the caller of this function may want to constrain negative
+          or very small prices to be somewhat larger in order to avoid extreme
+          proportional changes in price.
+          Note this is NOT an array of marginal tax rates (MTR), but rather
+            usually 1-MTR (or in the case of quantities, like charitable
+            giving, whose MTR values are non-positive, 1+MTR).
+
+    aftertax_price2: numpy array
+        marginal aftertax price of the quantity under reform policy
+          Note that this function forces prices to be in [0.01, inf] range,
+          but the caller of this function may want to constrain negative
+          or very small prices to be somewhat larger in order to avoid extreme
+          proportional changes in price.
+          Note this is NOT an array of marginal tax rates (MTR), but rather
+            usually 1-MTR (or in the case of quantities, like charitable
+            giving, whose MTR values are non-positive, 1+MTR).
+
+    income_elasticity: float
+        coefficient of the percentage change in aftertax income in the
+        log-log response equation
+
+    aftertax_income1: numpy array
+        aftertax income under baseline policy
+          Note that this function forces income to be in [1, inf] range,
+          but the caller of this function may want to constrain negative
+          or small incomes to be somewhat larger in order to avoid extreme
+          proportional changes in aftertax income.
+
+    aftertax_income2: numpy array
+        aftertax income under reform policy
+          Note that this function forces income to be in [1, inf] range,
+          but the caller of this function may want to constrain negative
+          or small incomes to be somewhat larger in order to avoid extreme
+          proportional changes in aftertax income.
+
+    Returns
+    -------
+    response: numpy array
+        dollar change in quantity calculated from log-log response equation
+    """
+    # pylint: disable=too-many-arguments
+    # compute price term in log-log response equation
+    if price_elasticity == 0.:
+        pch_price = np.zeros(quantity.shape)
+    else:
+        atp1 = np.where(aftertax_price1 < 0.01, 0.01, aftertax_price1)
+        atp2 = np.where(aftertax_price2 < 0.01, 0.01, aftertax_price2)
+        pch_price = atp2 / atp1 - 1.
+    # compute income term in log-log response equation
+    if income_elasticity == 0.:
+        pch_income = np.zeros(quantity.shape)
+    else:
+        ati1 = np.where(aftertax_income1 < 1.0, 1.0, aftertax_income1)
+        ati2 = np.where(aftertax_income2 < 1.0, 1.0, aftertax_income2)
+        pch_income = ati2 / ati1 - 1.
+    # compute response
+    pch_q = price_elasticity * pch_price + income_elasticity * pch_income
+    qresponse = pch_q * quantity
+    return qresponse

--- a/behresp/tests/test_behavior.py
+++ b/behresp/tests/test_behavior.py
@@ -9,7 +9,7 @@ from io import StringIO
 import numpy as np
 import pandas as pd
 import taxcalc as tc
-from behresp import PARAM_INFO, response
+from behresp import PARAM_INFO, response, quantity_response
 
 
 def test_param_info():
@@ -176,3 +176,27 @@ def test_sub_effect_independence():
     assert np.allclose(chg_funit1, chg_funit2)
     del chg_funit1
     del chg_funit2
+
+
+def test_quantity_response():
+    """
+    Test quantity_response function.
+    """
+    quantity = np.array([1.0] * 10)
+    res = quantity_response(quantity,
+                            price_elasticity=0,
+                            aftertax_price1=None,
+                            aftertax_price2=None,
+                            income_elasticity=0,
+                            aftertax_income1=None,
+                            aftertax_income2=None)
+    assert np.allclose(res, np.zeros(quantity.shape))
+    one = np.ones(quantity.shape)
+    res = quantity_response(quantity,
+                            price_elasticity=-0.2,
+                            aftertax_price1=one,
+                            aftertax_price2=one,
+                            income_elasticity=0.1,
+                            aftertax_income1=one,
+                            aftertax_income2=(one + one))
+    assert not np.allclose(res, np.zeros(quantity.shape))

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,14 +13,17 @@ div { max-width: 19cm }
 
 <p>This document tells you how to use Behavioral-Responses, an
 open-source model in the Policy Simulation Library (PSL) collection of
-USA tax models.  You always use Behavioral-Responses in conjunction with
+USA tax models.  It assumes that you have already read the
+<a href="https://github.com/PSLmodels/Behavioral-Responses#behavioral-responses">
+documentation introduction</a>.  You always use Behavioral-Responses
+in conjunction with
 <a href="https://PSLmodels.github.io/Tax-Calculator/">
 Tax-Calculator</a>, the static-analysis model in the PSL collection of
 USA tax models, by writing and executing a Python script.  For an
 introduction to writing Python scripts using Tax-Calculator, read the
 tested recipes in our
 <a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
-Tax-Calculator Cookbook</a>.  If you want to participate in the
+Tax-Calculator cookbook</a>.  If you want to participate in the
 development of Behavioral-Responses &mdash; by asking a question,
 reporting a bug, improving the documentation or making an enhancement
 to the Python source code &mdash; you should go to
@@ -28,11 +31,12 @@ the <a href="https://github.com/PSLmodels/Behavioral-Responses">
 developer website</a>.</p>
 
 <p>Please cite the source of your analysis as <q>Behavioral-Responses
-release #.#.#, author's calculations.</q> If you wish to link to
-Behavioral-Responses, this page is preferred.  Additionally, we strongly
-recommend that you describe the input data used, and provide a link to
-the materials required to replicate your analysis or, at least, note
-that those materials are available upon request.</p>
+release #.#.#, author's calculations.</q>  If you wish to link to
+Behavioral-Responses, this page is preferred.  Additionally, we
+strongly recommend that you describe the elasticity parameters used,
+and provide a link to the materials required to replicate your
+analysis or, at least, note that those materials are available upon
+request.</p>
 
 
 <h2 id="doc">Document Contents</h2>
@@ -48,7 +52,9 @@ that those materials are available upon request.</p>
 behavior.py</a> file, where the parameters are defined in the
 <kbd>PARAM_INFO</kbd> dictionary, and the logic of how those parameters
 are used along with Tax-Calculator results is defined in the
-<kbd>response</kbd> function.</p>
+higher-level <kbd>response</kbd> function.  The lower-level <kbd>
+quantity_response</kbd> function is self-contained and described in
+the functions's docstring.</p>
 
 <p>An interface to Behavioral-Responses for the
 <a href="https://www.ospc.org/taxbrain/">TaxBrain web application</a>
@@ -64,7 +70,7 @@ tbi.py</a> file.  But this is of interest only to TaxBrain developers.</p>
 <p>A tested recipe for using the Behavioral-Responses parameters and
 <kbd>response</kbd> function is contained in recipe 2 of the
 <a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
-Tax-Calculator Cookbook</a> and in the <kbd>test_response_function</kbd> in the
+Tax-Calculator cookbook</a> and in the <kbd>test_response_function</kbd> in the
 <a href="https://github.com/PSLmodels/Behavioral-Responses/blob/master/behresp/tests/test_behavior.py">
 test_behavior.py</a> file.</p>
 
@@ -85,13 +91,13 @@ operating-system command prompt:
 </pre>
 </p>
 
-<p>The Behavioral-Responses logic assumes that the parameters apply to
-all filing units.  If you want to estimate responses where the value
-of the parameters vary across (say, earnings) groups, you can use the
-Tax-Calculator <kbd>quantity_response</kbd> function.  A recipe for
-doing this is contained in the
+<p>The Behavioral-Responses logic assumes that the elasticity
+parameters apply to all filing units.  If you want to estimate
+responses where the value of the elasticity parameters vary across
+(say, earnings) groups, you can use the <kbd>quantity_response</kbd>
+function.  A recipe for doing this is contained in recipe 4 of the
 <a href="https://PSLmodels.github.io/Tax-Calculator/cookbook.html">
-Tax-Calculator Cookbook</a>.  That recipe simply estimates the
+Tax-Calculator cookbook</a>.  That recipe simply estimates the
 responses.  But the techniques used in the Behavioral-Responses
 <kbd>response</kbd> function can be used to apply the estimated
 responses to the post-reform Tax-Calculator object and recompute


### PR DESCRIPTION
This pull request adds the Tax-Calculator `quantity_response` function to the Behavioral-Responses repository.  This is the logical place for it because Tax-Calculator does only static tax analysis, as was pointed out by @MaxGhenis in [this comment](https://github.com/PSLmodels/Tax-Calculator/issues/2189#issuecomment-461261511).  There will be a companion Tax-Calculator pull request that removes the `quantity_response` function.