### PR TITLE
Make changes so code can work with Tax-Calculator 1.0+

### DIFF
--- a/behresp/behavior.py
+++ b/behresp/behavior.py
@@ -62,7 +62,7 @@ def response(calc_1, calc_2, behavior, dump=False):
       And neither calc_1 nor calc_2 are affected by this response function.
 
     The behavior argument is a dictionary returned from the Tax-Calculator
-    Calculator.read_json_assumptions method.
+    Calculator.read_json_parameters method.
 
     The optional dump argument controls the number of variables included
     in the two returned DataFrame objects.  When dump=False (its default

--- a/behresp/tests/test_behavior.py
+++ b/behresp/tests/test_behavior.py
@@ -55,7 +55,7 @@ def test_default_response_function(cps_subsample):
     df2s = calc2s.dataframe(['iitax', 's006'])
     itax2s = round((df2s['iitax'] * df2s['s006']).sum() * 1e-9, 3)
     # ... calculate aggregate inctax using default behavior assumptions
-    default_beh_dict = tc.Calculator.read_json_assumptions('{}')
+    default_beh_dict = tc.Calculator.read_json_parameters('{}')
     _, df2d = response(calc1, calc2d, default_beh_dict, dump=True)
     itax2d = round((df2d['iitax'] * df2d['s006']).sum() * 1e-9, 3)
     assert np.allclose(itax2d, itax2s)
@@ -82,7 +82,7 @@ def test_nondefault_response_function(cps_subsample):
     "BE_inc": {"2018": -0.1},
     "BE_cg": {"2018": -0.79}
     }"""
-    beh_dict = tc.Calculator.read_json_assumptions(beh_json)
+    beh_dict = tc.Calculator.read_json_parameters(beh_json)
     # ... calculate behavioral response to reform
     pol = tc.Policy()
     calc1 = tc.Calculator(records=rec, policy=pol)
@@ -98,7 +98,7 @@ def test_nondefault_response_function(cps_subsample):
     itax2 = round((df2['iitax'] * df2['s006']).sum() * 1e-9, 3)
     del df1
     del df2
-    assert np.allclose([itax1, itax2], [1422.156, 1368.489])
+    assert np.allclose([itax1, itax2], [1441.722, 1385.666])
 
 
 def test_alternative_behavior_parameters(cps_subsample):
@@ -112,7 +112,7 @@ def test_alternative_behavior_parameters(cps_subsample):
     assert refyear >= 2018
     reform = {refyear: {'_II_em': [1500]}}
     # ... specify alternative set of behavior parameters
-    beh_dict = tc.Calculator.read_json_assumptions(
+    beh_dict = tc.Calculator.read_json_parameters(
         '{"BE_inc": {"2018": -0.10}}'
     )
     # ... use the alternative behavior parameters and dump option
@@ -198,7 +198,7 @@ def test_sub_effect_independence(stcg):
     recs = tc.Records(data=input_dataframe,
                       start_year=refyear,
                       gfactors=None, weights=None)
-    beh_dict = tc.Calculator.read_json_assumptions(beh_json)
+    beh_dict = tc.Calculator.read_json_parameters(beh_json)
     pol = tc.Policy()
     calc1 = tc.Calculator(records=recs, policy=pol)
     assert calc1.current_year == refyear

--- a/behresp/tests/test_tbi.py
+++ b/behresp/tests/test_tbi.py
@@ -17,7 +17,7 @@ def test_parameter_errors():
     Test parameter_errors function.
     """
     behv_json = '{"BE_sub": {"2018": -0.25}}'
-    behv_dict = tc.Calculator.read_json_assumptions(behv_json)
+    behv_dict = tc.Calculator.read_json_parameters(behv_json)
     errmsg = parameter_errors(behv_dict, 2013, 10)
     assert errmsg
 
@@ -33,7 +33,7 @@ def test_behavioral_response(cps_subsample):
     reform_json = '{"policy": {"_II_em": {"2020": [1500]}}}'
     params = tc.Calculator.read_json_param_objects(reform_json, None)
     beh_json = '{"BE_sub": {"2013": 0.25}}'
-    beh_dict = tc.Calculator.read_json_assumptions(beh_json)
+    beh_dict = tc.Calculator.read_json_parameters(beh_json)
     # specify keyword arguments used in tbi function call
     kwargs = {
         'start_year': 2019,
@@ -44,8 +44,6 @@ def test_behavioral_response(cps_subsample):
             'policy': params['policy'],
             'growdiff_baseline': params['growdiff_baseline'],
             'growdiff_response': params['growdiff_response'],
-            'behavior': params['behavior'],
-            'growmodel': params['growmodel'],
             'consumption': params['consumption']
         },
         'behavior': beh_dict,
@@ -139,7 +137,7 @@ def test_fuzzing_and_returning_dict():
     reform_json = '{"policy": {"_II_em": {"2020": [1500]}}}'
     params = tc.Calculator.read_json_param_objects(reform_json, None)
     beh_json = '{"BE_sub": {"2013": 0.25}}'
-    beh_dict = tc.Calculator.read_json_assumptions(beh_json)
+    beh_dict = tc.Calculator.read_json_parameters(beh_json)
     # specify keyword arguments used in tbi function call
     kwargs = {
         'start_year': 2020,
@@ -150,8 +148,6 @@ def test_fuzzing_and_returning_dict():
             'policy': params['policy'],
             'growdiff_baseline': params['growdiff_baseline'],
             'growdiff_response': params['growdiff_response'],
-            'behavior': params['behavior'],
-            'growmodel': params['growmodel'],
             'consumption': params['consumption']
         },
         'behavior': beh_dict,

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,11 +5,11 @@ package:
 requirements:
   build:
     - python
-    - taxcalc
+    - "taxcalc>=1.0"
 
   run:
     - python
-    - taxcalc
+    - "taxcalc>=1.0"
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,4 @@ channels:
 - PSLmodels
 dependencies:
 - python
-- taxcalc
+- "taxcalc>=1.0"


### PR DESCRIPTION
This pull request updates the Behavioral-Responses code so that it works with Tax-Calculator releases 1.0 and higher.  There are no substantive changes in logic.