### PR TITLE
Revise Makefile to use pbrelease --local option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ help:
 clean:
 	@find . -name *pyc -exec rm {} \;
 	@find . -name *cache -maxdepth 1 -exec rm -r {} \;
-	@./conda.recipe/remove_local_package.sh
+	@conda uninstall behresp --yes --quiet 2>&1 > /dev/null
 
 .PHONY=package
 package:
-	@cd conda.recipe ; ./install_local_package.sh
+	@pbrelease Behavioral-Responses behresp 0.0.0 --local .
 
 define pytest-cleanup
 find . -name *cache -maxdepth 1 -exec rm -r {} \;


### PR DESCRIPTION
First step of a two-step process that replaces the `conda.recipe/install_local_package.sh` with the new `pbrelease --local` option, which requires installation of Package-Builder's `pkgbld` 0.21.0 package.

If usage is smooth, the second step of the replacement process will remove the `conda.recipe/install_local_package.sh` and `conda.recipe/remove_local_package.sh` files from the repository.