### PR TITLE
Update documentation and test results for T-C 1.1.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,23 @@ Go [here](https://github.com/PSLmodels/Behavioral-Responses/pulls?q=is%3Apr+is%3
 for a complete commit history.
 
 
+2019-03-xx Release 0.7.0
+------------------------
+(last merged pull request is
+[#52](https://github.com/PSLmodels/Behavioral-Responses/pull/52))
+
+**API Changes**
+- Simplify elasticities argument of the `response` function
+  [[#51](https://github.com/PSLmodels/Behavioral-Responses/pull/51)
+  by Martin Holmer]
+
+**New Features**
+- None
+
+**Bug Fixes**
+- None
+
+
 2019-02-22 Release 0.6.0
 ------------------------
 (last merged pull request is
@@ -18,7 +35,6 @@ for a complete commit history.
 - Add optional dump argument to the `response` function
   [[#39](https://github.com/PSLmodels/Behavioral-Responses/pull/39)
   by Martin Holmer responding to request by Matt Jensen and Anderson Frailey]
-
 - Add `quantity_response` function that was formerly a Tax-Calculator utility function and that provides a lower-level behavioral response capability
   [[#43](https://github.com/PSLmodels/Behavioral-Responses/pull/43)
   by Martin Holmer responding to suggestion by Max Ghenis]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ Go [here](https://github.com/PSLmodels/Behavioral-Responses/pulls?q=is%3Apr+is%3
 for a complete commit history.
 
 
-2019-03-xx Release 0.7.0
+2019-03-17 Release 0.7.0
 ------------------------
 (last merged pull request is
 [#52](https://github.com/PSLmodels/Behavioral-Responses/pull/52))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,7 @@ RELEASING BEHAVIORAL-RESPONSES CONDA PACKAGES
 
 --> create release X.Y.Z on GitHub using master branch
 
---> create packages using this command:
-    `pbrelease Behavioral-Responses behresp X.Y.Z --also37`
+--> run `pbrelease Behavioral-Responses behresp X.Y.Z` [to bld/upload packages]
 
 --> email policybrains-modelers list about the new release and packages
 ```

--- a/behresp/tests/test_behavior.py
+++ b/behresp/tests/test_behavior.py
@@ -74,7 +74,7 @@ def test_nondefault_response_function(cps_subsample):
     itax2 = round((df2['iitax'] * df2['s006']).sum() * 1e-9, 3)
     del df1
     del df2
-    assert np.allclose([itax1, itax2], [1441.725, 1385.680])
+    assert np.allclose([itax1, itax2], [1457.443, 1402.367])
 
 
 def test_alternative_behavior_parameters(cps_subsample):
@@ -103,7 +103,7 @@ def test_alternative_behavior_parameters(cps_subsample):
     itax2 = round((df2['iitax'] * df2['s006']).sum() * 1e-9, 3)
     del df1
     del df2
-    assert np.allclose([itax1, itax2], [1441.725, 1383.64])
+    assert np.allclose([itax1, itax2], [1457.443, 1399.183])
 
 
 def test_quantity_response():

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,11 +5,11 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>=1.0"
+    - "taxcalc>=1.1.0"
 
   run:
     - python
-    - "taxcalc>=1.0"
+    - "taxcalc>=1.1.0"
 
 test:
   imports:

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@ open-source model in the Policy Simulation Library (PSL) collection of
 USA tax models.  It assumes that you have already read the
 <a href="https://github.com/PSLmodels/Behavioral-Responses#behavioral-responses">
 documentation introduction</a>.  You always use Behavioral-Responses
-in conjunction with
+in conjunction with the latest version of
 <a href="https://PSLmodels.github.io/Tax-Calculator/">
 Tax-Calculator</a>, the static-analysis model in the PSL collection of
 USA tax models, by writing and executing a Python script.  For an
@@ -47,13 +47,14 @@ request.</p>
 
 <h2 id="paramlogic">Response Parameters and Logic</h2>
 
-<p>The Behavioral-Responses parameters and logic are described in the
+<p>The Behavioral-Responses elasticity parameters and logic are
+described in the
 <a href="https://github.com/PSLmodels/Behavioral-Responses/blob/master/behresp/behavior.py">
-behavior.py</a> file, where the parameters are defined in the
-<kbd>PARAM_INFO</kbd> dictionary, and the logic of how those parameters
-are used along with Tax-Calculator results is defined in the
-higher-level <kbd>response</kbd> function.  The lower-level <kbd>
-quantity_response</kbd> function is self-contained and described in
+behavior.py</a> file, where the <kbd>response</kbd> function
+elasticities are defined in its docstring and the logic of how those
+elasticities are used along with Tax-Calculator results is defined in the
+higher-level <kbd>response</kbd> function.  The lower-level
+<kbd>quantity_response</kbd> function is self-contained and described in
 the functions's docstring.</p>
 
 <p>An interface to Behavioral-Responses for the

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,4 @@ channels:
 - PSLmodels
 dependencies:
 - python
-- "taxcalc>=1.0"
+- "taxcalc>=1.1.0"


### PR DESCRIPTION
This pull request updates the `RELEASES.md` info and other documentation.  A couple of test results have changed slightly because of the use of the new economic projection in Tax-Calculator release 1.1.0.