### PR TITLE
Add pytest.ini file and use Tax-Calculator 2.3 capabilities

### DIFF
--- a/behresp/behavior.py
+++ b/behresp/behavior.py
@@ -164,7 +164,8 @@ def response(calc_1, calc_2, elasticities, dump=False):
     assert calc1.current_year == calc2.current_year
     mtr_cap = 0.99
     if dump:
-        dvars = list(tc.Records.USABLE_READ_VARS | tc.Records.CALCULATED_VARS)
+        recs_varinfo = tc.Records(data=None)  # contains records VARINFO only
+        dvars = recs_varinfo.USABLE_READ_VARS | recs_varinfo.CALCULATED_VARS
     # Calculate sum of substitution and income effects
     if be_sub == 0.0 and be_inc == 0.0:
         zero_sub_and_inc = True

--- a/behresp/behavior.py
+++ b/behresp/behavior.py
@@ -164,8 +164,8 @@ def response(calc_1, calc_2, elasticities, dump=False):
     assert calc1.current_year == calc2.current_year
     mtr_cap = 0.99
     if dump:
-        recs_varinfo = tc.Records(data=None)  # contains records VARINFO only
-        dvars = recs_varinfo.USABLE_READ_VARS | recs_varinfo.CALCULATED_VARS
+        recs_vinfo = tc.Records(data=None)  # contains records VARINFO only
+        dvars = list(recs_vinfo.USABLE_READ_VARS | recs_vinfo.CALCULATED_VARS)
     # Calculate sum of substitution and income effects
     if be_sub == 0.0 and be_inc == 0.0:
         zero_sub_and_inc = True

--- a/behresp/tests/test_4package.py
+++ b/behresp/tests/test_4package.py
@@ -34,7 +34,7 @@ def test_for_consistency(tests_path):
     meta_file = os.path.join(tests_path, '..', '..',
                              'conda.recipe', 'meta.yaml')
     with open(meta_file, 'r') as stream:
-        meta = yaml.load(stream)
+        meta = yaml.safe_load(stream)
     bld = set(meta['requirements']['build'])
     run = set(meta['requirements']['run'])
     # confirm conda.recipe/meta.yaml build and run requirements are the same
@@ -43,7 +43,7 @@ def test_for_consistency(tests_path):
     envr_file = os.path.join(tests_path, '..', '..',
                              'environment.yml')
     with open(envr_file, 'r') as stream:
-        envr = yaml.load(stream)
+        envr = yaml.safe_load(stream)
     env = set(envr['dependencies'])
     # confirm that environment and run packages are the same
     assert env == run

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,11 +5,11 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>=1.1.0"
+    - "taxcalc>=2.3.0"
 
   run:
     - python
-    - "taxcalc>=1.1.0"
+    - "taxcalc>=2.3.0"
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,11 +5,11 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>=2.2.0"
+    - "taxcalc>=2.3.0"
 
   run:
     - python
-    - "taxcalc>=2.2.0"
+    - "taxcalc>=2.3.0"
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,11 +5,11 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>=2.3.0"
+    - "taxcalc>=2.2.0"
 
   run:
     - python
-    - "taxcalc>=2.3.0"
+    - "taxcalc>=2.2.0"
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,4 @@ channels:
 - PSLmodels
 dependencies:
 - python
-- "taxcalc>=2.2.0"
+- "taxcalc>=2.3.0"

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,4 @@ channels:
 - PSLmodels
 dependencies:
 - python
-- "taxcalc>=2.3.0"
+- "taxcalc>=2.2.0"

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,4 @@ channels:
 - PSLmodels
 dependencies:
 - python
-- "taxcalc>=1.1.0"
+- "taxcalc>=2.3.0"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths =
+    behresp
+markers =
+    local
+    pep8
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-testpaths = behresp


### PR DESCRIPTION
Consolidate pytest directives in the new `pytest.ini` file.
Specify list of dump variables using capabilities available in forthcoming Tax-Calculator release 2.3.
No changes in behavior logic or results.