### PR TITLE
Fix .coveragerc file contents

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,3 @@
 [run]
 omit =
-    behresp/_version.py
-    behresp/*json
-    behresp/tbi.py
     behresp/tests/*


### PR DESCRIPTION
Eliminate obsolete entries in the `.coveragerc` file.